### PR TITLE
replace use of .push() in map with direct assignment

### DIFF
--- a/__tests__/__fixtures__/cached/map/output.js
+++ b/__tests__/__fixtures__/cached/map/output.js
@@ -2,8 +2,7 @@ let _result = [];
 
 for (let _key = 0, _length = array.length, _value; _key < _length; ++_key) {
   _value = array[_key];
-
-  _result.push(fn(_value, _key, array));
+  _result[_key] = fn(_value, _key, array);
 }
 
 const doubledValues = _result;

--- a/__tests__/__fixtures__/cached/mapRight/output.js
+++ b/__tests__/__fixtures__/cached/mapRight/output.js
@@ -2,8 +2,7 @@ let _result = [];
 
 for (let _key = array.length - 1, _value; _key >= 0; --_key) {
   _value = array[_key];
-
-  _result.push(fn(_value, _key, array));
+  _result[_result.length] = fn(_value, _key, array);
 }
 
 const doubledValues = _result;

--- a/__tests__/__fixtures__/inlined-arrow-expression/map/output.js
+++ b/__tests__/__fixtures__/inlined-arrow-expression/map/output.js
@@ -2,8 +2,7 @@ let _result = [];
 
 for (let _key = 0, _length = array.length, _value; _key < _length; ++_key) {
   _value = array[_key];
-
-  _result.push(_value * 2);
+  _result[_key] = _value * 2;
 }
 
 const doubledValues = _result;

--- a/__tests__/__fixtures__/inlined-arrow-expression/mapRight/output.js
+++ b/__tests__/__fixtures__/inlined-arrow-expression/mapRight/output.js
@@ -2,8 +2,7 @@ let _result = [];
 
 for (let _key = array.length - 1, _value; _key >= 0; --_key) {
   _value = array[_key];
-
-  _result.push(_value * 2);
+  _result[_result.length] = _value * 2;
 }
 
 const doubledValues = _result;

--- a/__tests__/__fixtures__/inlined-arrow-return/map/output.js
+++ b/__tests__/__fixtures__/inlined-arrow-return/map/output.js
@@ -2,8 +2,7 @@ let _result = [];
 
 for (let _key = 0, _length = array.length, _value; _key < _length; ++_key) {
   _value = array[_key];
-
-  _result.push(_value * 2);
+  _result[_key] = _value * 2;
 }
 
 const doubledValues = _result;

--- a/__tests__/__fixtures__/inlined-arrow-return/mapRight/output.js
+++ b/__tests__/__fixtures__/inlined-arrow-return/mapRight/output.js
@@ -2,8 +2,7 @@ let _result = [];
 
 for (let _key = array.length - 1, _value; _key >= 0; --_key) {
   _value = array[_key];
-
-  _result.push(_value * 2);
+  _result[_result.length] = _value * 2;
 }
 
 const doubledValues = _result;

--- a/__tests__/__fixtures__/inlined-function-return/map/output.js
+++ b/__tests__/__fixtures__/inlined-function-return/map/output.js
@@ -2,8 +2,7 @@ let _result = [];
 
 for (let _key = 0, _length = array.length, _value; _key < _length; ++_key) {
   _value = array[_key];
-
-  _result.push(_value * 2);
+  _result[_key] = _value * 2;
 }
 
 const doubledValues = _result;

--- a/__tests__/__fixtures__/inlined-function-return/mapRight/output.js
+++ b/__tests__/__fixtures__/inlined-function-return/mapRight/output.js
@@ -2,8 +2,7 @@ let _result = [];
 
 for (let _key = array.length - 1, _value; _key >= 0; --_key) {
   _value = array[_key];
-
-  _result.push(_value * 2);
+  _result[_result.length] = _value * 2;
 }
 
 const doubledValues = _result;

--- a/__tests__/__fixtures__/nested/contrived/output.js
+++ b/__tests__/__fixtures__/nested/contrived/output.js
@@ -2,8 +2,7 @@ let _result = [];
 
 for (let _key = 0, _length = array.length, _value; _key < _length; ++_key) {
   _value = array[_key];
-
-  _result.push(_value * 2);
+  _result[_key] = _value * 2;
 }
 
 let _result2 = {};

--- a/__tests__/__fixtures__/nested/deep-iterable/output.js
+++ b/__tests__/__fixtures__/nested/deep-iterable/output.js
@@ -2,8 +2,7 @@ let _result = [];
 
 for (let _key = 0, _length = array.length, _value; _key < _length; ++_key) {
   _value = array[_key];
-
-  _result.push(cachedFn(_value, _key, array));
+  _result[_key] = cachedFn(_value, _key, array);
 }
 
 for (let _key2 = 0, _length2 = _result.length, _value2; _key2 < _length2; ++_key2) {

--- a/__tests__/__fixtures__/nested/jsx/output.js
+++ b/__tests__/__fixtures__/nested/jsx/output.js
@@ -6,10 +6,9 @@ function List(props) {
 
   for (let _key = 0, _length = _iterable.length, _value; _key < _length; ++_key) {
     _value = _iterable[_key];
-
-    _result.push(React.createElement("li", {
+    _result[_key] = React.createElement("li", {
       key: _value.id
-    }, _value.value));
+    }, _value.value);
   }
 
   return React.createElement("ul", null, _result);

--- a/__tests__/__fixtures__/nested/shallow-iterable/output.js
+++ b/__tests__/__fixtures__/nested/shallow-iterable/output.js
@@ -13,7 +13,7 @@ for (let _key = 0, _length = array.length, _value; _key < _length; ++_key) {
     }
   }
 
-  _result.push(_result2);
+  _result[_key] = _result2;
 }
 
 const allStrings = _result;

--- a/__tests__/__fixtures__/nested/shallow-map/output.js
+++ b/__tests__/__fixtures__/nested/shallow-map/output.js
@@ -3,8 +3,7 @@ let _result = [];
 
 for (let _key = 0, _length = array.length, _value; _key < _length; ++_key) {
   _value = array[_key];
-
-  _result.push(cachedFn(_value, _key, array));
+  _result[_key] = cachedFn(_value, _key, array);
 }
 
 const isEqual = deepEqual(_result, [1, 2, 3]);

--- a/__tests__/__fixtures__/uncached/map/output.js
+++ b/__tests__/__fixtures__/uncached/map/output.js
@@ -9,8 +9,7 @@ let _result = [];
 
 for (let _key = 0, _length = _iterable.length, _value; _key < _length; ++_key) {
   _value = _iterable[_key];
-
-  _result.push(_fn(_value, _key, _iterable));
+  _result[_key] = _fn(_value, _key, _iterable);
 }
 
 const doubledValues = _result;

--- a/__tests__/__fixtures__/uncached/mapRight/output.js
+++ b/__tests__/__fixtures__/uncached/mapRight/output.js
@@ -9,8 +9,7 @@ let _result = [];
 
 for (let _key = _iterable.length - 1, _value; _key >= 0; --_key) {
   _value = _iterable[_key];
-
-  _result.push(_fn(_value, _key, _iterable));
+  _result[_result.length] = _fn(_value, _key, _iterable);
 }
 
 const doubledValues = _result;

--- a/__tests__/transform.test.js
+++ b/__tests__/transform.test.js
@@ -17,7 +17,7 @@ pluginTester({
   fixtures: path.join(__dirname, '__fixtures__', 'inlined-arrow-expression'),
   filename: __filename,
   plugin,
-  title: 'Inlined function references (arrow expreasion)',
+  title: 'Inlined function references (arrow expression)',
 });
 
 pluginTester({

--- a/dist/handlers.js
+++ b/dist/handlers.js
@@ -284,7 +284,7 @@ function handleMap(_ref6) {
   var iterableUsed = isIterableCached ? object : iterable;
   var valueAssignment = t.expressionStatement(t.assignmentExpression('=', value, t.memberExpression(iterableUsed, key, true)));
   var resultStatement = getResultStatement(t, handler, fnUsed, value, key, iterableUsed, path);
-  var expr = t.expressionStatement(isObject ? t.assignmentExpression('=', t.memberExpression(result, key, true), resultStatement) : t.callExpression(t.memberExpression(result, t.identifier('push')), [resultStatement]));
+  var expr = t.expressionStatement(isDecrementing ? t.assignmentExpression('=', t.memberExpression(result, t.memberExpression(result, t.identifier('length')), true), resultStatement) : t.assignmentExpression('=', t.memberExpression(result, key, true), resultStatement));
   var loop = getLoop({
     t: t,
     body: t.blockStatement([valueAssignment, expr]),

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -23,27 +23,13 @@ function handleEvery({
   const iterableUsed = isIterableCached ? object : iterable;
 
   const valueAssignment = t.expressionStatement(
-    t.assignmentExpression(
-      '=',
-      value,
-      t.memberExpression(iterableUsed, key, true),
-    ),
+    t.assignmentExpression('=', value, t.memberExpression(iterableUsed, key, true)),
   );
-  const resultStatement = getResultStatement(
-    t,
-    handler,
-    fnUsed,
-    value,
-    key,
-    iterableUsed,
-    path,
-  );
+  const resultStatement = getResultStatement(t, handler, fnUsed, value, key, iterableUsed, path);
   const expr = t.ifStatement(
     t.unaryExpression('!', resultStatement),
     t.blockStatement([
-      t.expressionStatement(
-        t.assignmentExpression('=', result, t.booleanLiteral(false)),
-      ),
+      t.expressionStatement(t.assignmentExpression('=', result, t.booleanLiteral(false))),
       t.breakStatement(),
     ]),
   );
@@ -92,31 +78,14 @@ function handleFilter({
   const iterableUsed = isIterableCached ? object : iterable;
 
   const valueAssignment = t.expressionStatement(
-    t.assignmentExpression(
-      '=',
-      value,
-      t.memberExpression(iterableUsed, key, true),
-    ),
+    t.assignmentExpression('=', value, t.memberExpression(iterableUsed, key, true)),
   );
   const resultAssignment = isObject
     ? t.assignmentExpression('=', t.memberExpression(result, key, true), value)
-    : t.callExpression(t.memberExpression(result, t.identifier('push')), [
-      value,
-    ]);
+    : t.callExpression(t.memberExpression(result, t.identifier('push')), [value]);
 
-  const resultStatement = getResultStatement(
-    t,
-    handler,
-    fnUsed,
-    value,
-    key,
-    iterableUsed,
-    path,
-  );
-  const expr = t.ifStatement(
-    resultStatement,
-    t.expressionStatement(resultAssignment),
-  );
+  const resultStatement = getResultStatement(t, handler, fnUsed, value, key, iterableUsed, path);
+  const expr = t.ifStatement(resultStatement, t.expressionStatement(resultAssignment));
 
   const loop = getLoop({
     t,
@@ -162,21 +131,9 @@ function handleFind({
   const iterableUsed = isIterableCached ? object : iterable;
 
   const valueAssignment = t.expressionStatement(
-    t.assignmentExpression(
-      '=',
-      value,
-      t.memberExpression(iterableUsed, key, true),
-    ),
+    t.assignmentExpression('=', value, t.memberExpression(iterableUsed, key, true)),
   );
-  const resultStatement = getResultStatement(
-    t,
-    handler,
-    fnUsed,
-    value,
-    key,
-    iterableUsed,
-    path,
-  );
+  const resultStatement = getResultStatement(t, handler, fnUsed, value, key, iterableUsed, path);
   const expr = t.ifStatement(
     resultStatement,
     t.blockStatement([
@@ -228,21 +185,9 @@ function handleFindKey({
   const iterableUsed = isIterableCached ? object : iterable;
 
   const valueAssignment = t.expressionStatement(
-    t.assignmentExpression(
-      '=',
-      value,
-      t.memberExpression(iterableUsed, key, true),
-    ),
+    t.assignmentExpression('=', value, t.memberExpression(iterableUsed, key, true)),
   );
-  const resultStatement = getResultStatement(
-    t,
-    handler,
-    fnUsed,
-    value,
-    key,
-    iterableUsed,
-    path,
-  );
+  const resultStatement = getResultStatement(t, handler, fnUsed, value, key, iterableUsed, path);
   const expr = t.ifStatement(
     resultStatement,
     t.blockStatement([
@@ -295,21 +240,9 @@ function handleForEach({
   const iterableUsed = isIterableCached ? object : iterable;
 
   const valueAssignment = t.expressionStatement(
-    t.assignmentExpression(
-      '=',
-      value,
-      t.memberExpression(iterableUsed, key, true),
-    ),
+    t.assignmentExpression('=', value, t.memberExpression(iterableUsed, key, true)),
   );
-  const resultStatement = getResultStatement(
-    t,
-    handler,
-    fnUsed,
-    value,
-    key,
-    iterableUsed,
-    path,
-  );
+  const resultStatement = getResultStatement(t, handler, fnUsed, value, key, iterableUsed, path);
   const call = t.expressionStatement(resultStatement);
 
   const loop = getLoop({
@@ -354,31 +287,17 @@ function handleMap({
   const iterableUsed = isIterableCached ? object : iterable;
 
   const valueAssignment = t.expressionStatement(
-    t.assignmentExpression(
-      '=',
-      value,
-      t.memberExpression(iterableUsed, key, true),
-    ),
+    t.assignmentExpression('=', value, t.memberExpression(iterableUsed, key, true)),
   );
-  const resultStatement = getResultStatement(
-    t,
-    handler,
-    fnUsed,
-    value,
-    key,
-    iterableUsed,
-    path,
-  );
+  const resultStatement = getResultStatement(t, handler, fnUsed, value, key, iterableUsed, path);
   const expr = t.expressionStatement(
-    isObject
+    isDecrementing
       ? t.assignmentExpression(
         '=',
-        t.memberExpression(result, key, true),
+        t.memberExpression(result, t.memberExpression(result, t.identifier('length')), true),
         resultStatement,
       )
-      : t.callExpression(t.memberExpression(result, t.identifier('push')), [
-        resultStatement,
-      ]),
+      : t.assignmentExpression('=', t.memberExpression(result, key, true), resultStatement),
   );
 
   const loop = getLoop({
@@ -412,13 +331,7 @@ function handleMap({
 }
 
 function handleReduce({
-  t,
-  path,
-  object,
-  handler,
-  initialValue,
-  isDecrementing,
-  isObject,
+  t, path, object, handler, initialValue, isDecrementing, isObject,
 }) {
   const {
     fn, iterable, key, length, result, value,
@@ -447,10 +360,7 @@ function handleReduce({
     } else if (isDecrementing) {
       injected.push(
         t.variableDeclaration('const', [
-          t.variableDeclarator(
-            length,
-            t.memberExpression(iterableUsed, t.identifier('length')),
-          ),
+          t.variableDeclarator(length, t.memberExpression(iterableUsed, t.identifier('length'))),
         ]),
       );
 
@@ -460,11 +370,7 @@ function handleReduce({
         true,
       );
     } else {
-      initialValue = t.memberExpression(
-        iterableUsed,
-        t.numericLiteral(0),
-        true,
-      );
+      initialValue = t.memberExpression(iterableUsed, t.numericLiteral(0), true);
     }
   }
 
@@ -473,11 +379,7 @@ function handleReduce({
   }
 
   const valueAssignment = t.expressionStatement(
-    t.assignmentExpression(
-      '=',
-      value,
-      t.memberExpression(iterableUsed, key, true),
-    ),
+    t.assignmentExpression('=', value, t.memberExpression(iterableUsed, key, true)),
   );
   const resultStatement = getReduceResultStatement(
     t,
@@ -496,20 +398,13 @@ function handleReduce({
   if (!hasInitialValue && isObject) {
     const ifHasInitialValue = t.ifStatement(
       hasInitialValueId,
-      t.blockStatement([
-        valueAssignment,
-        t.expressionStatement(resultAssignment),
-      ]),
+      t.blockStatement([valueAssignment, t.expressionStatement(resultAssignment)]),
       t.blockStatement([
         t.expressionStatement(
           t.assignmentExpression('=', hasInitialValueId, t.booleanLiteral(true)),
         ),
         t.expressionStatement(
-          t.assignmentExpression(
-            '=',
-            result,
-            t.memberExpression(iterableUsed, key, true),
-          ),
+          t.assignmentExpression('=', result, t.memberExpression(iterableUsed, key, true)),
         ),
       ]),
     );
@@ -532,9 +427,7 @@ function handleReduce({
   });
 
   if (!hasInitialValue && !isObject) {
-    const keyValue = loop.init.declarations.find(
-      ({ id }) => id.name === key.name,
-    );
+    const keyValue = loop.init.declarations.find(({ id }) => id.name === key.name);
 
     if (isDecrementing) {
       keyValue.init.left = length;
@@ -547,9 +440,7 @@ function handleReduce({
   const insertBefore = [];
 
   if (iterableUsed === iterable) {
-    const iterableVar = t.variableDeclaration('const', [
-      t.variableDeclarator(iterable, object),
-    ]);
+    const iterableVar = t.variableDeclaration('const', [t.variableDeclarator(iterable, object)]);
 
     insertBefore.push(iterableVar);
   }
@@ -557,16 +448,12 @@ function handleReduce({
   insertBefore.push(...injected);
 
   if (fnUsed === fn && resultStatement.__inlineLoopsMacroFallback) {
-    const handlerVar = t.variableDeclaration('const', [
-      t.variableDeclarator(fn, handler),
-    ]);
+    const handlerVar = t.variableDeclaration('const', [t.variableDeclarator(fn, handler)]);
 
     insertBefore.push(handlerVar);
   }
 
-  const resultVar = t.variableDeclaration('let', [
-    t.variableDeclarator(result, initialValue),
-  ]);
+  const resultVar = t.variableDeclaration('let', [t.variableDeclarator(result, initialValue)]);
 
   insertBefore.push(resultVar);
 
@@ -591,27 +478,13 @@ function handleSome({
   const iterableUsed = isIterableCached ? object : iterable;
 
   const valueAssignment = t.expressionStatement(
-    t.assignmentExpression(
-      '=',
-      value,
-      t.memberExpression(iterableUsed, key, true),
-    ),
+    t.assignmentExpression('=', value, t.memberExpression(iterableUsed, key, true)),
   );
-  const resultStatement = getResultStatement(
-    t,
-    handler,
-    fnUsed,
-    value,
-    key,
-    iterableUsed,
-    path,
-  );
+  const resultStatement = getResultStatement(t, handler, fnUsed, value, key, iterableUsed, path);
   const expr = t.ifStatement(
     resultStatement,
     t.blockStatement([
-      t.expressionStatement(
-        t.assignmentExpression('=', result, t.booleanLiteral(true)),
-      ),
+      t.expressionStatement(t.assignmentExpression('=', result, t.booleanLiteral(true))),
       t.breakStatement(),
     ]),
   );


### PR DESCRIPTION
- When incrementing, use direct assignment of index (much faster than .push())
- When decrementing, use direct assignment with current result length (mildly faster than .push())

In both cases, it will minify smaller.