### PR TITLE
Ensure `forEach*` methods include the `returned` value when the function is hoisted

### DIFF
--- a/__tests__/__fixtures__/complex/for-each-hoisted/code.js
+++ b/__tests__/__fixtures__/complex/for-each-hoisted/code.js
@@ -1,0 +1,12 @@
+const { forEach } = require('../../../../src/inline-loops.macro');
+import { log } from './log';
+
+function logItems(items) {
+  forEach(items, (item) => {
+    if (!item.position) {
+      return;
+    }
+
+    log(item);
+  });
+}

--- a/__tests__/__fixtures__/complex/for-each-hoisted/output.js
+++ b/__tests__/__fixtures__/complex/for-each-hoisted/output.js
@@ -1,0 +1,15 @@
+import { log } from './log';
+function logItems(items) {
+  (() => {
+    const _fn = (_item) => {
+      if (!_item.position) {
+        return;
+      }
+      log(_item);
+    };
+    for (let _key = 0, _length = items.length, _item; _key < _length; ++_key) {
+      _item = items[_key];
+      _fn(_item, _key, items);
+    }
+  })();
+}

--- a/__tests__/__fixtures__/complex/for-each-right-hoisted/code.js
+++ b/__tests__/__fixtures__/complex/for-each-right-hoisted/code.js
@@ -1,0 +1,12 @@
+const { forEachRight } = require('../../../../src/inline-loops.macro');
+import { log } from './log';
+
+function logItems(items) {
+  forEachRight(items, (item) => {
+    if (!item.position) {
+      return;
+    }
+
+    log(item);
+  });
+}

--- a/__tests__/__fixtures__/complex/for-each-right-hoisted/output.js
+++ b/__tests__/__fixtures__/complex/for-each-right-hoisted/output.js
@@ -1,0 +1,15 @@
+import { log } from './log';
+function logItems(items) {
+  (() => {
+    const _fn = (_item) => {
+      if (!_item.position) {
+        return;
+      }
+      log(_item);
+    };
+    for (let _key = items.length, _item; --_key >= 0; ) {
+      _item = items[_key];
+      _fn(_item, _key, items);
+    }
+  })();
+}

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -120,7 +120,12 @@ export function createHandlers(babel: MacroParams['babel']) {
         getCachedFnArgs(local, isReduce),
       );
 
-      return { injectedBody: [], returned };
+      return isForEach
+        ? {
+            injectedBody: [t.expressionStatement(returned)],
+            returned: undefined,
+          }
+        : { injectedBody: [], returned };
     }
 
     if (handler.isFunction()) {


### PR DESCRIPTION
## Reason for change
I discovered that when the contents of the loop were hoisted to a function, the call of that function was getting dropped in `forEach`. This is because the conditionality to make the returned value the injected body was not being applied specifically in that scenario.

## Change
If the method is a `forEach` method, inject the returned expression as an expression statement.